### PR TITLE
feat(plugin): complete WASI plugin system integration

### DIFF
--- a/crates/minal-ai/src/factory.rs
+++ b/crates/minal-ai/src/factory.rs
@@ -36,6 +36,9 @@ fn create_single_provider(
                 OpenAiProvider::new(api_key, config.base_url.clone(), config.model.clone())?;
             Ok(Arc::new(provider))
         }
+        AiProviderKind::Plugin => Err(AiError::Provider(
+            "plugin AI providers are created via PluginManager, not the factory".to_string(),
+        )),
     }
 }
 

--- a/crates/minal-config/src/ai.rs
+++ b/crates/minal-config/src/ai.rs
@@ -14,6 +14,9 @@ pub enum AiProviderKind {
     /// OpenAI API.
     #[serde(rename = "openai")]
     OpenAi,
+    /// A WASM plugin-provided AI backend.
+    /// Use the `plugin_provider` field in `AiConfig` to specify the plugin name.
+    Plugin,
 }
 
 /// How to retrieve the API key for cloud providers.
@@ -373,6 +376,9 @@ pub struct AiConfig {
     /// Agent mode settings.
     #[serde(default)]
     pub agent: AgentConfig,
+    /// Name of the plugin to use as AI provider (when `provider = "plugin"`).
+    #[serde(default)]
+    pub plugin_provider: Option<String>,
 }
 
 impl Default for AiConfig {
@@ -394,6 +400,7 @@ impl Default for AiConfig {
             chat: ChatConfig::default(),
             session_analysis: SessionAnalysisConfig::default(),
             agent: AgentConfig::default(),
+            plugin_provider: None,
         }
     }
 }
@@ -500,6 +507,19 @@ mod tests {
             chat: ChatConfig::default(),
             session_analysis: SessionAnalysisConfig::default(),
             agent: AgentConfig::default(),
+            plugin_provider: None,
+        };
+        let s = toml::to_string(&cfg).unwrap();
+        let cfg2: AiConfig = toml::from_str(&s).unwrap();
+        assert_eq!(cfg, cfg2);
+    }
+
+    #[test]
+    fn serialize_roundtrip_plugin_provider() {
+        let cfg = AiConfig {
+            provider: AiProviderKind::Plugin,
+            plugin_provider: Some("my-ai-plugin".to_string()),
+            ..AiConfig::default()
         };
         let s = toml::to_string(&cfg).unwrap();
         let cfg2: AiConfig = toml::from_str(&s).unwrap();
@@ -671,6 +691,13 @@ mod tests {
         };
         let s = toml::to_string(&cfg).unwrap();
         assert!(s.contains("\"anthropic\""));
+
+        let cfg = AiConfig {
+            provider: AiProviderKind::Plugin,
+            ..AiConfig::default()
+        };
+        let s = toml::to_string(&cfg).unwrap();
+        assert!(s.contains("\"plugin\""));
     }
 
     #[test]

--- a/crates/minal-plugin/src/ai_bridge.rs
+++ b/crates/minal-plugin/src/ai_bridge.rs
@@ -49,7 +49,7 @@ impl WasmAiProvider {
     ///
     /// Spawns a background thread that owns the `PluginInstance` and
     /// processes AI requests.
-    pub fn new(name: String, mut instance: PluginInstance) -> Self {
+    pub fn new(name: String, mut instance: PluginInstance) -> Result<Self, PluginError> {
         let (tx, rx) = std::sync::mpsc::channel::<AiRequest>();
 
         std::thread::Builder::new()
@@ -83,12 +83,12 @@ impl WasmAiProvider {
                 }
                 tracing::debug!("plugin AI worker thread exiting");
             })
-            .expect("failed to spawn plugin AI worker thread");
+            .map_err(PluginError::ThreadSpawn)?;
 
-        Self {
+        Ok(Self {
             name,
             sender: Arc::new(tx),
-        }
+        })
     }
 }
 

--- a/crates/minal-plugin/src/error.rs
+++ b/crates/minal-plugin/src/error.rs
@@ -45,4 +45,8 @@ pub enum PluginError {
     /// Plugin directory does not exist.
     #[error("plugin directory not found: {0}")]
     DirNotFound(String),
+
+    /// Failed to spawn a plugin worker thread.
+    #[error("failed to spawn worker thread: {0}")]
+    ThreadSpawn(#[source] std::io::Error),
 }

--- a/crates/minal-plugin/src/manager.rs
+++ b/crates/minal-plugin/src/manager.rs
@@ -260,7 +260,12 @@ impl PluginManager {
             .ok_or_else(|| PluginError::NotLoaded(name.to_string()))?;
 
         let provider_name = ai_config.name.clone();
-        Ok(WasmAiProvider::new(provider_name, instance))
+        WasmAiProvider::new(provider_name, instance)
+    }
+
+    /// Returns `true` if any loaded plugin subscribes to output events.
+    pub fn has_output_hooks(&self) -> bool {
+        !self.hooks.output_hooks.is_empty()
     }
 
     /// List all loaded plugin names.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,340 @@
+# Minal Plugin Development Guide
+
+This guide explains how to build WASI-based plugins for the Minal terminal
+emulator. Plugins run in a sandboxed WebAssembly environment and can extend
+Minal with event hooks and custom AI providers.
+
+## Overview
+
+Minal plugins are compiled as WebAssembly modules targeting `wasm32-wasip1`.
+Each plugin lives in its own directory alongside a `plugin.toml` manifest that
+declares metadata, event subscriptions, and optional AI provider capabilities.
+
+```
+my-plugin/
+├── plugin.toml          # Plugin manifest (required)
+├── plugin.wasm          # Compiled WASM module (or custom path)
+└── data/                # Optional data files (read-only access)
+```
+
+## Quick Start
+
+### 1. Create a Rust library
+
+```bash
+cargo new --lib my-plugin
+cd my-plugin
+```
+
+Set the crate type in `Cargo.toml`:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+### 2. Write the plugin manifest
+
+Create `plugin.toml`:
+
+```toml
+[plugin]
+name = "my-plugin"
+version = "0.1.0"
+description = "My first Minal plugin"
+author = "Your Name"
+wasm_path = "target/wasm32-wasip1/release/my_plugin.wasm"
+
+[hooks]
+on_command = true
+on_output = false
+on_error = true
+```
+
+### 3. Implement the ABI
+
+```rust
+use std::alloc::{Layout, alloc};
+
+#[no_mangle]
+pub extern "C" fn minal_alloc(size: i32) -> i32 {
+    if size <= 0 { return 0; }
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(size as usize, 1);
+        alloc(layout) as i32
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn minal_init() {
+    // One-time initialization
+}
+
+#[no_mangle]
+pub extern "C" fn minal_on_command(ptr: i32, len: i32) -> i64 {
+    let input = read_input(ptr, len);
+    let response = r#"{"suppress":false,"message":"Hello from my-plugin!"}"#;
+    pack_string(response)
+}
+```
+
+### 4. Build and install
+
+```bash
+# Add the WASI target (one-time)
+rustup target add wasm32-wasip1
+
+# Build
+cargo build --target wasm32-wasip1 --release
+
+# Install (copy the directory to the plugin path)
+mkdir -p ~/.config/minal/plugins/my-plugin
+cp plugin.toml ~/.config/minal/plugins/my-plugin/
+cp target/wasm32-wasip1/release/my_plugin.wasm \
+   ~/.config/minal/plugins/my-plugin/plugin.wasm
+```
+
+### 5. Enable plugins in Minal config
+
+Add to `~/.config/minal/minal.toml`:
+
+```toml
+[plugins]
+enabled = true
+plugin_dirs = ["~/.config/minal/plugins"]
+```
+
+## Plugin ABI Reference
+
+### Required Export
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `minal_alloc` | `(size: i32) -> i32` | Allocate `size` bytes in plugin memory, return pointer |
+
+### Optional Exports
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `minal_init` | `() -> ()` | Called once after loading |
+| `minal_info` | `() -> i64` | Return plugin metadata as packed `(ptr, len)` |
+| `minal_on_command` | `(ptr: i32, len: i32) -> i64` | Command hook |
+| `minal_on_output` | `(ptr: i32, len: i32) -> i64` | Output hook |
+| `minal_on_error` | `(ptr: i32, len: i32) -> i64` | Error hook |
+| `minal_ai_complete` | `(ptr: i32, len: i32) -> i64` | AI completion |
+| `minal_ai_analyze_error` | `(ptr: i32, len: i32) -> i64` | AI error analysis |
+
+### Return Value Encoding
+
+Functions that return string data use a packed i64:
+- **High 32 bits**: pointer to the string data in WASM memory
+- **Low 32 bits**: length of the string in bytes
+- A return value of `0` means "no data" (the hook is a no-op)
+
+```rust
+fn pack_string(s: &str) -> i64 {
+    let bytes = s.as_bytes();
+    let ptr = minal_alloc(bytes.len() as i32);
+    if ptr == 0 { return 0; }
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr as *mut u8, bytes.len());
+    }
+    ((ptr as i64) << 32) | (bytes.len() as i64)
+}
+```
+
+## Event Types
+
+### PluginEvent::Command
+
+Sent when a shell command is entered (detected via OSC 133).
+
+```json
+{
+  "type": "command",
+  "command": "cargo build",
+  "working_dir": "/home/user/project"
+}
+```
+
+### PluginEvent::Output
+
+Sent when terminal output is received from the PTY.
+
+```json
+{
+  "type": "output",
+  "data": "Compiling minal v0.1.0\n"
+}
+```
+
+### PluginEvent::Error
+
+Sent when a command exits with a non-zero status.
+
+```json
+{
+  "type": "error",
+  "command": "cargo test",
+  "exit_code": 1,
+  "stderr": "error[E0308]: mismatched types..."
+}
+```
+
+## Hook Response
+
+All hook functions return a JSON `HookResponse`:
+
+```json
+{
+  "suppress": false,
+  "modified_command": null,
+  "message": "Optional message to display"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `suppress` | `bool` | If `true`, the event is suppressed |
+| `modified_command` | `string?` | Modified command text (command hooks only) |
+| `message` | `string?` | Message to display to the user |
+
+## AI Provider Plugins
+
+Plugins can provide custom AI backends by exporting `minal_ai_complete` and
+optionally `minal_ai_analyze_error`.
+
+### Manifest
+
+```toml
+[plugin]
+name = "my-ai"
+version = "0.1.0"
+
+[ai_provider]
+name = "my-ai"
+```
+
+### Configuration
+
+In `minal.toml`:
+
+```toml
+[ai]
+provider = "plugin"
+plugin_provider = "my-ai"
+enabled = true
+
+[plugins]
+enabled = true
+```
+
+### AI Complete
+
+Receives a JSON-encoded `AiContext` and returns a completion string:
+
+```rust
+#[no_mangle]
+pub extern "C" fn minal_ai_complete(ptr: i32, len: i32) -> i64 {
+    let context_json = read_input(ptr, len);
+    // Parse context, generate completion...
+    let completion = "ls -la";
+    pack_string(completion)
+}
+```
+
+### AI Error Analysis
+
+Receives a JSON-encoded `ErrorContext` and returns a JSON `ErrorAnalysis`:
+
+```rust
+#[no_mangle]
+pub extern "C" fn minal_ai_analyze_error(ptr: i32, len: i32) -> i64 {
+    let error_json = read_input(ptr, len);
+    let analysis = r#"{
+        "summary": "Command not found",
+        "suggestion": "Install the package with: brew install foo",
+        "severity": "low",
+        "category": "user_error"
+    }"#;
+    pack_string(analysis)
+}
+```
+
+## Security Model
+
+Plugins run in a WASI sandbox with the following constraints:
+
+- **Filesystem**: Read-only access to the plugin's own directory only
+- **Network**: No network access
+- **System calls**: Limited to WASI preview 1 capabilities
+- **Memory**: Isolated WASM linear memory
+- **Stdio**: Inherited from the host (stdout/stderr visible in terminal)
+
+Plugins cannot:
+- Access files outside their directory
+- Make network requests
+- Execute arbitrary system commands
+- Access other plugins' memory
+
+## Plugin Manager API
+
+For programmatic use (e.g., in tests):
+
+```rust
+use minal_plugin::PluginManager;
+use std::path::Path;
+
+// Create a manager (optionally with an allowlist)
+let mut mgr = PluginManager::new(vec![])?;
+
+// Scan a directory for plugins
+let loaded = mgr.scan_directory(Path::new("/path/to/plugins"))?;
+
+// Dispatch an event
+use minal_plugin::PluginEvent;
+let event = PluginEvent::Command {
+    command: "ls -la".to_string(),
+    working_dir: "/home/user".to_string(),
+};
+let responses = mgr.dispatch_event(&event)?;
+
+// Extract an AI provider
+let provider = mgr.take_ai_provider("my-ai")?;
+```
+
+## Examples
+
+See the `examples/plugins/` directory for complete working examples:
+
+- **hello-plugin**: Minimal event hook plugin (on_command, on_error)
+- **echo-ai-provider**: Example AI provider plugin
+
+Build an example:
+
+```bash
+cd examples/plugins/hello-plugin
+cargo build --target wasm32-wasip1 --release
+```
+
+## Troubleshooting
+
+### Plugin not loading
+
+- Check that `plugin.toml` exists in the plugin directory
+- Verify `wasm_path` in the manifest points to a valid `.wasm` file
+- Check Minal logs for detailed error messages
+- Ensure `[plugins] enabled = true` in your config
+
+### Hook not firing
+
+- Verify the hook is enabled in `plugin.toml` (e.g., `on_command = true`)
+- For output hooks, ensure the plugin subscribes to `on_output = true`
+- Check that shell integration (OSC 133) is set up for command/error hooks
+
+### AI provider not working
+
+- Ensure both `[plugins] enabled = true` and `[ai] provider = "plugin"` are set
+- Set `plugin_provider = "my-plugin-name"` in the `[ai]` section
+- Verify the plugin exports `minal_ai_complete`
+- Note: streaming chat (`chat_stream`) is not supported for WASM providers

--- a/examples/plugins/echo-ai-provider/Cargo.toml
+++ b/examples/plugins/echo-ai-provider/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "echo-ai-provider"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/plugins/echo-ai-provider/plugin.toml
+++ b/examples/plugins/echo-ai-provider/plugin.toml
@@ -1,0 +1,9 @@
+[plugin]
+name = "echo-ai"
+version = "0.1.0"
+description = "Example AI provider plugin that echoes back prompts."
+author = "Minal Contributors"
+wasm_path = "target/wasm32-wasip1/release/echo_ai_provider.wasm"
+
+[ai_provider]
+name = "echo-ai"

--- a/examples/plugins/echo-ai-provider/src/lib.rs
+++ b/examples/plugins/echo-ai-provider/src/lib.rs
@@ -1,0 +1,75 @@
+//! Echo AI Provider Plugin — example custom AI provider for Minal.
+//!
+//! Demonstrates the AI provider plugin ABI by implementing `minal_ai_complete`
+//! and `minal_ai_analyze_error`. The completion function echoes back the last
+//! command from the context, and the error analysis returns a fixed suggestion.
+
+use std::alloc::{Layout, alloc};
+
+/// Allocator export required by the Minal plugin ABI.
+#[no_mangle]
+pub extern "C" fn minal_alloc(size: i32) -> i32 {
+    if size <= 0 {
+        return 0;
+    }
+    // SAFETY: size > 0 guarantees a valid layout.
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(size as usize, 1);
+        alloc(layout) as i32
+    }
+}
+
+/// Called once after the plugin is loaded.
+#[no_mangle]
+pub extern "C" fn minal_init() {}
+
+/// Return plugin metadata.
+#[no_mangle]
+pub extern "C" fn minal_info() -> i64 {
+    let json = r#"{"name":"echo-ai","version":"0.1.0","type":"ai_provider"}"#;
+    pack_string(json)
+}
+
+/// AI completion: receives JSON context, returns a completion string.
+///
+/// This example simply echoes back "echo: <input>" as the completion.
+#[no_mangle]
+pub extern "C" fn minal_ai_complete(ptr: i32, len: i32) -> i64 {
+    let input = read_input(ptr, len);
+    let response = format!("echo: {input}");
+    pack_string(&response)
+}
+
+/// AI error analysis: receives JSON error context, returns a JSON ErrorAnalysis.
+#[no_mangle]
+pub extern "C" fn minal_ai_analyze_error(ptr: i32, len: i32) -> i64 {
+    let _input = read_input(ptr, len);
+    let analysis = r#"{"summary":"Error detected by echo-ai plugin","suggestion":"Check the command syntax and try again.","severity":"low","category":"user_error"}"#;
+    pack_string(analysis)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn read_input(ptr: i32, len: i32) -> String {
+    if ptr <= 0 || len <= 0 {
+        return String::new();
+    }
+    // SAFETY: The host writes valid UTF-8 JSON into the allocated region.
+    unsafe {
+        let slice = std::slice::from_raw_parts(ptr as *const u8, len as usize);
+        String::from_utf8_lossy(slice).into_owned()
+    }
+}
+
+fn pack_string(s: &str) -> i64 {
+    let bytes = s.as_bytes();
+    let ptr = minal_alloc(bytes.len() as i32);
+    if ptr == 0 {
+        return 0;
+    }
+    // SAFETY: minal_alloc returned a valid pointer for `bytes.len()` bytes.
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr as *mut u8, bytes.len());
+    }
+    ((ptr as i64) << 32) | (bytes.len() as i64)
+}

--- a/examples/plugins/hello-plugin/Cargo.toml
+++ b/examples/plugins/hello-plugin/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hello-plugin"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/plugins/hello-plugin/plugin.toml
+++ b/examples/plugins/hello-plugin/plugin.toml
@@ -1,0 +1,11 @@
+[plugin]
+name = "hello-plugin"
+version = "0.1.0"
+description = "A minimal example plugin that logs commands and errors."
+author = "Minal Contributors"
+wasm_path = "target/wasm32-wasip1/release/hello_plugin.wasm"
+
+[hooks]
+on_command = true
+on_output = false
+on_error = true

--- a/examples/plugins/hello-plugin/src/lib.rs
+++ b/examples/plugins/hello-plugin/src/lib.rs
@@ -1,0 +1,92 @@
+//! Hello Plugin — minimal Minal plugin example.
+//!
+//! Demonstrates the plugin ABI by subscribing to `on_command` and `on_error`
+//! hooks. Returns a greeting message for every command and a diagnostic
+//! message for every error.
+
+use std::alloc::{Layout, alloc};
+
+/// Allocator export required by the Minal plugin ABI.
+///
+/// The host calls this to reserve memory in the plugin before writing
+/// JSON event data.
+#[no_mangle]
+pub extern "C" fn minal_alloc(size: i32) -> i32 {
+    if size <= 0 {
+        return 0;
+    }
+    // SAFETY: size > 0 guarantees a valid layout.
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(size as usize, 1);
+        alloc(layout) as i32
+    }
+}
+
+/// Called once after the plugin is loaded.
+#[no_mangle]
+pub extern "C" fn minal_init() {
+    // Nothing to initialize for this example.
+}
+
+/// Return plugin metadata as a packed `(ptr << 32) | len` i64.
+#[no_mangle]
+pub extern "C" fn minal_info() -> i64 {
+    let json = r#"{"name":"hello-plugin","version":"0.1.0"}"#;
+    pack_string(json)
+}
+
+/// Command hook: receives a JSON `PluginEvent::Command`, returns a `HookResponse`.
+#[no_mangle]
+pub extern "C" fn minal_on_command(ptr: i32, len: i32) -> i64 {
+    let input = read_input(ptr, len);
+    let response = format!(
+        r#"{{"suppress":false,"message":"[hello-plugin] saw command: {}"}}"#,
+        escape_json_string(&input)
+    );
+    pack_string(&response)
+}
+
+/// Error hook: receives a JSON `PluginEvent::Error`, returns a `HookResponse`.
+#[no_mangle]
+pub extern "C" fn minal_on_error(ptr: i32, len: i32) -> i64 {
+    let input = read_input(ptr, len);
+    let response = format!(
+        r#"{{"suppress":false,"message":"[hello-plugin] saw error: {}"}}"#,
+        escape_json_string(&input)
+    );
+    pack_string(&response)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn read_input(ptr: i32, len: i32) -> String {
+    if ptr <= 0 || len <= 0 {
+        return String::new();
+    }
+    // SAFETY: The host writes valid UTF-8 JSON into the allocated region.
+    unsafe {
+        let slice = std::slice::from_raw_parts(ptr as *const u8, len as usize);
+        String::from_utf8_lossy(slice).into_owned()
+    }
+}
+
+fn pack_string(s: &str) -> i64 {
+    let bytes = s.as_bytes();
+    let ptr = minal_alloc(bytes.len() as i32);
+    if ptr == 0 {
+        return 0;
+    }
+    // SAFETY: minal_alloc returned a valid pointer for `bytes.len()` bytes.
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr as *mut u8, bytes.len());
+    }
+    ((ptr as i64) << 32) | (bytes.len() as i64)
+}
+
+fn escape_json_string(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -142,6 +142,8 @@ pub struct App {
     mcp_config: Option<minal_config::McpConfig>,
     /// WASI plugin manager.
     plugin_manager: Option<minal_plugin::PluginManager>,
+    /// Plugin-backed AI provider, if config requests one.
+    plugin_ai_provider: Option<std::sync::Arc<dyn minal_ai::provider::AiProvider>>,
     /// Timestamp of the last frame for animation delta time.
     last_frame_time: Instant,
     /// Timestamp of the last completed render (for frame-skip throttling).
@@ -176,6 +178,7 @@ impl App {
             mcp_panel: None,
             mcp_config: None,
             plugin_manager: None,
+            plugin_ai_provider: None,
             last_frame_time: Instant::now(),
             last_render_time: Instant::now(),
             pending_updates: 0,
@@ -243,6 +246,12 @@ impl App {
         let shell = config.shell.resolve_program();
         let env_vars = shell_integration_env_vars();
 
+        let plugins_have_output_hooks = self
+            .plugin_manager
+            .as_ref()
+            .is_some_and(|mgr| mgr.has_output_hooks());
+        let ai_provider_override = self.plugin_ai_provider.clone();
+
         match crate::pane::Pane::spawn(
             pane_id,
             rows,
@@ -252,6 +261,8 @@ impl App {
             &config.ai,
             self.mcp_config.clone().unwrap_or_default(),
             &env_vars,
+            plugins_have_output_hooks,
+            ai_provider_override,
         ) {
             Ok(pane) => Some(pane),
             Err(e) => {
@@ -1801,6 +1812,12 @@ impl ApplicationHandler<WakeupReason> for App {
         });
         self.mcp_config = Some(mcp_config.clone());
 
+        let plugins_have_output_hooks = self
+            .plugin_manager
+            .as_ref()
+            .is_some_and(|mgr| mgr.has_output_hooks());
+        let ai_provider_override = self.plugin_ai_provider.clone();
+
         let pane = match crate::pane::Pane::spawn(
             pane_id,
             rows,
@@ -1810,6 +1827,8 @@ impl ApplicationHandler<WakeupReason> for App {
             &config.ai,
             mcp_config,
             &env_vars,
+            plugins_have_output_hooks,
+            ai_provider_override,
         ) {
             Ok(p) => p,
             Err(e) => {
@@ -1909,6 +1928,27 @@ impl ApplicationHandler<WakeupReason> for App {
                     let count = mgr.plugin_count();
                     if count > 0 {
                         tracing::info!(count, "plugin system initialized");
+                    }
+                    // If the config requests a plugin AI provider, extract it now.
+                    if matches!(config.ai.provider, minal_config::AiProviderKind::Plugin) {
+                        if let Some(ref plugin_name) = config.ai.plugin_provider {
+                            match mgr.take_ai_provider(plugin_name) {
+                                Ok(provider) => {
+                                    tracing::info!(
+                                        plugin = %plugin_name,
+                                        "plugin AI provider extracted"
+                                    );
+                                    self.plugin_ai_provider = Some(std::sync::Arc::new(provider));
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        plugin = %plugin_name,
+                                        error = %e,
+                                        "failed to extract plugin AI provider"
+                                    );
+                                }
+                            }
+                        }
                     }
                     self.plugin_manager = Some(mgr);
                 }
@@ -2100,6 +2140,10 @@ impl ApplicationHandler<WakeupReason> for App {
                         pane.prefetch_context();
                     }
                 }
+            }
+            WakeupReason::PaneOutputReceived(_pane_id, data) => {
+                let plugin_event = minal_plugin::PluginEvent::Output { data };
+                self.dispatch_plugin_event(&plugin_event);
             }
             WakeupReason::AiProviderStatus(pane_id, status) => {
                 tracing::info!(pane_id = pane_id.0, status = %status, "AI provider status");

--- a/src/event.rs
+++ b/src/event.rs
@@ -139,6 +139,8 @@ pub enum WakeupReason {
     PaneCommandCompleted(PaneId, minal_core::shell_integration::ShellCommandRecord),
     /// A new prompt started (OSC 133;A) — triggers context prefetch.
     PanePromptStarted(PaneId),
+    /// Terminal output received; forwarded to plugin output hooks.
+    PaneOutputReceived(PaneId, String),
     /// AI provider status notification (for status bar display).
     AiProviderStatus(PaneId, String),
     /// A macOS menu bar action was triggered.

--- a/src/io.rs
+++ b/src/io.rs
@@ -37,6 +37,8 @@ pub async fn pane_io_loop(
     proxy: EventLoopProxy<WakeupReason>,
     ai_config: minal_config::AiConfig,
     mcp_config: minal_config::McpConfig,
+    plugins_have_output_hooks: bool,
+    ai_provider_override: Option<Arc<dyn AiProvider>>,
 ) {
     let async_pty = match AsyncPty::from_pty(pty) {
         Ok(ap) => ap,
@@ -48,7 +50,9 @@ pub async fn pane_io_loop(
     };
 
     // Create AI provider if enabled.
-    let ai_provider: Option<Arc<dyn AiProvider>> = if ai_config.enabled {
+    let ai_provider: Option<Arc<dyn AiProvider>> = if let Some(provider) = ai_provider_override {
+        Some(provider)
+    } else if ai_config.enabled {
         let keystore = minal_ai::default_keystore(&ai_config);
         match minal_ai::create_provider(&ai_config, &*keystore) {
             Ok(provider) => {
@@ -227,6 +231,15 @@ pub async fn pane_io_loop(
                                         );
                                     }
                                 }
+                            }
+                            // Forward output to plugin hooks if any are registered.
+                            if plugins_have_output_hooks {
+                                let output_text =
+                                    String::from_utf8_lossy(&read_buf[..n]).to_string();
+                                let _ = proxy.send_event(WakeupReason::PaneOutputReceived(
+                                    pane_id,
+                                    output_text,
+                                ));
                             }
                             // Snapshot the terminal state while the lock is held, then
                             // publish it atomically so the renderer can read it without

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -62,6 +62,8 @@ impl Pane {
         ai_config: &minal_config::AiConfig,
         mcp_config: minal_config::McpConfig,
         env_vars: &[(String, String)],
+        plugins_have_output_hooks: bool,
+        ai_provider_override: Option<std::sync::Arc<dyn minal_ai::provider::AiProvider>>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let terminal = Arc::new(Mutex::new(Terminal::new(rows, cols)));
         let pty_size = PtySize::new(rows as u16, cols as u16);
@@ -107,6 +109,8 @@ impl Pane {
                     proxy,
                     ai_config_clone,
                     mcp_config,
+                    plugins_have_output_hooks,
+                    ai_provider_override,
                 ));
             })?;
 


### PR DESCRIPTION
## Summary
- Complete the WASI-based plugin system by closing integration gaps between minal-plugin and the rest of the application
- Fix `expect()` in `WasmAiProvider::new()` with proper error propagation via new `ThreadSpawn` error variant
- Add `AiProviderKind::Plugin` variant and `plugin_provider` config field so users can select plugin-based AI providers
- Wire output hook dispatch: PTY output now reaches plugins via `PaneOutputReceived` event
- Pass plugin AI provider override to I/O threads, bypassing the factory when a plugin provider is configured
- Add example plugins (`hello-plugin` for event hooks, `echo-ai-provider` for custom AI) and plugin development guide

Closes #27

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` — all 629 tests pass (0 failures)
- [ ] Manual: enable plugins in config, load hello-plugin, verify command/error hooks fire
- [ ] Manual: configure `provider = "plugin"` with echo-ai plugin, verify AI completions work
- [ ] Manual: build example plugins with `cargo build --target wasm32-wasip1 --release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now configure third-party plugins as AI providers through configuration
  * Terminal output events are now forwarded to plugin hooks for real-time processing

* **Documentation**
  * Added comprehensive plugin development guide with WASI architecture details
  * Included two example plugins: echo-ai-provider (AI completion) and hello-plugin (event hooks)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->